### PR TITLE
Commenting out 'document_end' for manifest

### DIFF
--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -8,7 +8,7 @@
 		{
 			"matches": ["*://*/*"],
 			"js": ["content_script.js"],
-			"run_at": "document_end"
+			//"run_at": "document_end"
 		}
 	]
 }


### PR DESCRIPTION
Checking to see if removing run_at: document_end fixes the loading extension bug